### PR TITLE
Fix generateMethod's generated code to avoid invoke return type mismatch.

### DIFF
--- a/lib/client_generator.dart
+++ b/lib/client_generator.dart
@@ -34,11 +34,15 @@ class ClientApiGenerator {
     var outputType = service._getDartClassName(m.outputType);
     out.addBlock(
         'Future<$outputType> $methodName('
-        'ClientContext ctx, $inputType request) {',
+        'ClientContext ctx, $inputType request) async {',
         '}', () {
       out.println('var emptyResponse = new $outputType();');
-      out.println('return _client.invoke(ctx, \'${service._descriptor.name}\', '
+      out.println('final response = await _client.invoke(ctx, \'${service._descriptor.name}\', '
           '\'${m.name}\', request, emptyResponse);');
+      
+      out.println('emptyResponse.mergeFromMessage(response);');
+      out.println('return emptyResponse;');
+
     });
   }
 }

--- a/lib/client_generator.dart
+++ b/lib/client_generator.dart
@@ -38,11 +38,8 @@ class ClientApiGenerator {
         '}', () {
       out.println('var emptyResponse = new $outputType();');
       out.println(
-          'final response = await _client.invoke(ctx, \'${service._descriptor.name}\', '
-          '\'${m.name}\', request, emptyResponse);');
-
-      out.println('emptyResponse.mergeFromMessage(response);');
-      out.println('return emptyResponse;');
+          'return await _client.invoke(ctx, \'${service._descriptor.name}\', '
+          '\'${m.name}\', request, emptyResponse) as $outputType;');
     });
   }
 }

--- a/lib/client_generator.dart
+++ b/lib/client_generator.dart
@@ -37,12 +37,12 @@ class ClientApiGenerator {
         'ClientContext ctx, $inputType request) async {',
         '}', () {
       out.println('var emptyResponse = new $outputType();');
-      out.println('final response = await _client.invoke(ctx, \'${service._descriptor.name}\', '
+      out.println(
+          'final response = await _client.invoke(ctx, \'${service._descriptor.name}\', '
           '\'${m.name}\', request, emptyResponse);');
-      
+
       out.println('emptyResponse.mergeFromMessage(response);');
       out.println('return emptyResponse;');
-
     });
   }
 }

--- a/test/client_generator_test.dart
+++ b/test/client_generator_test.dart
@@ -19,13 +19,13 @@ class TestApi {
   RpcClient _client;
   TestApi(this._client);
 
-  Future<SomeReply> aMethod(ClientContext ctx, SomeRequest request) {
+  Future<SomeReply> aMethod(ClientContext ctx, SomeRequest request) async {
     var emptyResponse = new SomeReply();
-    return _client.invoke(ctx, 'Test', 'AMethod', request, emptyResponse);
+    return await _client.invoke(ctx, 'Test', 'AMethod', request, emptyResponse) as SomeReply;
   }
-  Future<$foo$bar.AnotherReply> anotherMethod(ClientContext ctx, $foo$bar.EmptyMessage request) {
+  Future<$foo$bar.AnotherReply> anotherMethod(ClientContext ctx, $foo$bar.EmptyMessage request) async {
     var emptyResponse = new $foo$bar.AnotherReply();
-    return _client.invoke(ctx, 'Test', 'AnotherMethod', request, emptyResponse);
+    return await _client.invoke(ctx, 'Test', 'AnotherMethod', request, emptyResponse) as $foo$bar.AnotherReply;
   }
 }
 

--- a/test/file_generator_test.dart
+++ b/test/file_generator_test.dart
@@ -360,9 +360,9 @@ class TestApi {
   RpcClient _client;
   TestApi(this._client);
 
-  Future<Empty> ping(ClientContext ctx, Empty request) {
+  Future<Empty> ping(ClientContext ctx, Empty request) async {
     var emptyResponse = new Empty();
-    return _client.invoke(ctx, 'Test', 'Ping', request, emptyResponse);
+    return await _client.invoke(ctx, 'Test', 'Ping', request, emptyResponse) as Empty;
   }
 }
 


### PR DESCRIPTION
When I use the generated code in my flutter project, call the service method will get this exception:
`type 'Future<GeneratedMessage>' is not a subtype of type 'FutureOr<Response>'`

So, I change the dart-protoc-plugin to aviod the exception.