### PR TITLE
Use Future and Stream over ResponseFuture and ReponseStream in clients.

### DIFF
--- a/lib/grpc_generator.dart
+++ b/lib/grpc_generator.dart
@@ -157,8 +157,7 @@ class _GrpcMethod {
   final String _responseType;
 
   final String _argumentType;
-  final String _clientReturnType;
-  final String _serverReturnType;
+  final String _returnType;
 
   _GrpcMethod._(
       this._grpcName,
@@ -169,8 +168,7 @@ class _GrpcMethod {
       this._requestType,
       this._responseType,
       this._argumentType,
-      this._clientReturnType,
-      this._serverReturnType);
+      this._returnType);
 
   factory _GrpcMethod(GrpcServiceGenerator service, GenerationContext ctx,
       MethodDescriptorProto method) {
@@ -189,10 +187,7 @@ class _GrpcMethod {
 
     final argumentType =
         clientStreaming ? '\$async.Stream<$requestType>' : requestType;
-    final clientReturnType = serverStreaming
-        ? 'ResponseStream<$responseType>'
-        : 'ResponseFuture<$responseType>';
-    final serverReturnType = serverStreaming
+    final returnType = serverStreaming
         ? '\$async.Stream<$responseType>'
         : '\$async.Future<$responseType>';
 
@@ -205,8 +200,7 @@ class _GrpcMethod {
         requestType,
         responseType,
         argumentType,
-        clientReturnType,
-        serverReturnType);
+        returnType);
   }
 
   void generateClientMethodDescriptor(IndentingWriter out) {
@@ -221,7 +215,7 @@ class _GrpcMethod {
   void generateClientStub(IndentingWriter out) {
     out.println();
     out.addBlock(
-        '$_clientReturnType $_dartName($_argumentType request, {CallOptions options}) {',
+        '$_returnType $_dartName($_argumentType request, {CallOptions options}) {',
         '}', () {
       final requestStream = _clientStreaming
           ? 'request'
@@ -252,7 +246,7 @@ class _GrpcMethod {
     if (_clientStreaming) return;
 
     out.addBlock(
-        '$_serverReturnType ${_dartName}_Pre(ServiceCall call, \$async.Future request) async${_serverStreaming ? '*' : ''} {',
+        '$_returnType ${_dartName}_Pre(ServiceCall call, \$async.Future request) async${_serverStreaming ? '*' : ''} {',
         '}', () {
       if (_serverStreaming) {
         out.println(
@@ -266,6 +260,6 @@ class _GrpcMethod {
 
   void generateServiceMethodStub(IndentingWriter out) {
     out.println(
-        '$_serverReturnType $_dartName(ServiceCall call, $_argumentType request);');
+        '$_returnType $_dartName(ServiceCall call, $_argumentType request);');
   }
 }

--- a/test/goldens/grpc_service.pbgrpc
+++ b/test/goldens/grpc_service.pbgrpc
@@ -32,26 +32,26 @@ class TestClient extends Client {
   TestClient(ClientChannel channel, {CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<Output> unary(Input request, {CallOptions options}) {
+  $async.Future<Output> unary(Input request, {CallOptions options}) {
     final call = $createCall(_$unary, new $async.Stream.fromIterable([request]),
         options: options);
     return new ResponseFuture(call);
   }
 
-  ResponseFuture<Output> clientStreaming($async.Stream<Input> request,
+  $async.Future<Output> clientStreaming($async.Stream<Input> request,
       {CallOptions options}) {
     final call = $createCall(_$clientStreaming, request, options: options);
     return new ResponseFuture(call);
   }
 
-  ResponseStream<Output> serverStreaming(Input request, {CallOptions options}) {
+  $async.Stream<Output> serverStreaming(Input request, {CallOptions options}) {
     final call = $createCall(
         _$serverStreaming, new $async.Stream.fromIterable([request]),
         options: options);
     return new ResponseStream(call);
   }
 
-  ResponseStream<Output> bidirectional($async.Stream<Input> request,
+  $async.Stream<Output> bidirectional($async.Stream<Input> request,
       {CallOptions options}) {
     final call = $createCall(_$bidirectional, request, options: options);
     return new ResponseStream(call);


### PR DESCRIPTION
It appears ResponseFuture and ResponseStream are private implementaiton details of the grpc-dart library, and shouldn't be exposed as part of the interface to external users.  One of the main reasons for this is that using ResponseFuture / ResponseStream makes the gRPC Client extreamly difficult to mock for unit tests.

This fixes #135 